### PR TITLE
fix(validation): fix validation-exception-factory.ts

### DIFF
--- a/src/filters/validation-exception-factory.ts
+++ b/src/filters/validation-exception-factory.ts
@@ -7,7 +7,7 @@ export interface TransformedErrors {
 
 function transformErrors(errors: ValidationError[]): TransformedErrors[] {
   return errors.reduce((acc: TransformedErrors[], error: ValidationError) => {
-    if (error.children?.length !== 0) {
+    if (error.children?.length && error.children.length !== 0) {
       const childrenErrors = error.children as ValidationError[];
 
       return [...acc, ...transformErrors(childrenErrors)];


### PR DESCRIPTION
if unspecified property is provided in any DTO the app crashes with 500
**if (error.children?.length !== 0)** => in this case **error.children** is undefined, and undefined !== 0 is true