### PR TITLE
fix: file buffer typo

### DIFF
--- a/src/providers/s3/s3.service.ts
+++ b/src/providers/s3/s3.service.ts
@@ -88,7 +88,7 @@ export default class S3Service {
     const params = {
       Bucket: bucket,
       Key: fileName,
-      Body: file.buffe,
+      Body: file.buffer,
       ContentType: file.mimetype,
     };
 


### PR DESCRIPTION
there is typo in the s3 upload params it should be file.buffer instead of file.buffe